### PR TITLE
0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,21 @@
-## v0.3.0
+## v0.4.0
 
---- 
+- Debug mode is now set when creating a `Donkey` instance rather than creating
+  a `DonkeyServer` or `DonkeyClient`. This fixes issues where enabling debug
+  mode on the server / client and not on the other would sometimes disable debug
+  mode for both.
+- Turned on Clojure spec assertions
+- Global exception handler - In debug mode, a stack trace is added to the
+  exception if it doesn't include one.
+- Fixed release script not pushing changes to GitHub.
+
+## v0.3.0
 
 - Added support for user-defined error handlers when creating a server. The
   server options support a new field - `:error-handlers`. Users can supply a map
   of http-status-code -> handler-function.
 
 ## v0.2.0
-
----
 
 - `version-bump.sh` script was removed in favor of:
     - `version-change.sh` Update the project to a new version.

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ TOC Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)
 Including the library in `project.clj`
 
 ```clojure
-[com.appsflyer/donkey "0.3.0"]
+[com.appsflyer/donkey "0.4.0-SNAPSHOT"]
 ``` 
 
 Including the library in `deps.edn`
 
 ```clojure
-com.appsflyer/donkey {:mvn/version "0.3.0"}
+com.appsflyer/donkey {:mvn/version "0.4.0-SNAPSHOT"}
 ``` 
 
 Including the library in `pom.xml`
@@ -63,7 +63,7 @@ Including the library in `pom.xml`
 <dependency>
     <groupId>com.appsflyer</groupId>
     <artifactId>donkey</artifactId>
-    <version>0.3.0</version>
+    <version>0.4.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -639,7 +639,6 @@ them on every request
                       donkey/create-client 
                       {:default-host               "reqres.in"
                        :default-port               443
-                       :debug                      false
                        :ssl                        true
                        :keep-alive                 true
                        :keep-alive-timeout-seconds 30
@@ -941,17 +940,17 @@ Base name: `<:metrics-prefix>.http.clients`
 
 ## Debug mode
 
-Debug mode is activated when creating a server or a client with `:debug true`.
-In this mode several loggers are set to log at the `trace` level. It means the
-logs will be *very* verbose. For that reason it is not suitable for production
-use, and should only be enabled in development as needed.
+Debug mode is activated when creating a `Donkey` with `:debug true`. In this
+mode several loggers are set to log at the `trace` level. It means the logs will
+be *very* verbose. For that reason it is not suitable for production use, and
+should only be enabled in development as needed.
 
 The logs include:
 
 - All of Netty's low level networking, system configuration, memory leak
   detection logs and more.
-- Hexadecimal representation of each batch of packets being transmitted to the
-  server.
+- Hexadecimal representation of each batch of packets being transmitted to a
+  server or from a client.
 - Request routing, which is useful to debug a route that is not being matched.
 - Donkey trace logs.
 
@@ -981,14 +980,14 @@ when importing Donkey. For example:
 project.clj
 
 ```clojure
-:dependencies [com.appsflyer/donkey "0.3.0" :exclusions [io.dropwizard.metrics/metrics-core]]
+:dependencies [com.appsflyer/donkey "0.4.0-SNAPSHOT" :exclusions [io.dropwizard.metrics/metrics-core]]
 ```   
 
 deps.edn
 
 ```clojure
 {:deps
- {com.appsflyer/donkey {:mvn/version "0.3.0"
+ {com.appsflyer/donkey {:mvn/version "0.4.0-SNAPSHOT"
                        :exclusions [io.dropwizard.metrics/metrics-core]}}}
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <description>Clojure Server and Client</description>
     <groupId>com.appsflyer</groupId>
     <artifactId>donkey</artifactId>
-    <version>0.3.0</version>
+    <version>0.4.0-SNAPSHOT</version>
     <packaging>clojure</packaging>
     <url>https://github.com/AppsFlyer/donkey</url>
     <inceptionYear>2020</inceptionYear>

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
 (def ^:private ^:const ring-json-version "0.5.0")
 (def ^:private ^:const criterium-version "0.4.6")
 
-(defproject com.appsflyer/donkey "0.3.0"
+(defproject com.appsflyer/donkey "0.4.0-SNAPSHOT"
   :description "Clojure Server and Client"
   :url "https://github.com/AppsFlyer/donkey"
   :license {:name "APACHE LICENSE, VERSION 2.0"

--- a/release.sh
+++ b/release.sh
@@ -97,8 +97,10 @@ ask_do_push
 if [ $? = 0 ]; then
   if [ "$DRY_RUN" = 0 ]; then
     echo 'git push origin '"$TAG"
+    echo 'git push'
   else
     git push origin "$TAG"
+    git push
   fi
   exit_on_error "push failed"
 fi

--- a/src/main/clojure/com/appsflyer/donkey/donkey_spec.clj
+++ b/src/main/clojure/com/appsflyer/donkey/donkey_spec.clj
@@ -32,7 +32,8 @@
 (s/def ::donkey-config (s/keys :opt-un [::metrics-prefix
                                         ::metric-registry
                                         ::worker-threads
-                                        ::event-loops]))
+                                        ::event-loops
+                                        ::debug]))
 
 (s/def ::handler fn?)
 (s/def ::handlers (s/coll-of ::handler))
@@ -95,7 +96,6 @@
                                         ::compression
                                         ::decompression
                                         ::host
-                                        ::debug
                                         ::date-header
                                         ::content-type-header
                                         ::server-header
@@ -105,7 +105,8 @@
                                         ::socket-linger-seconds
                                         ::accept-backlog
                                         ::keep-alive
-                                        ::idle-timeout-seconds]))
+                                        ::idle-timeout-seconds
+                                        ::debug]))
 
 
 ;; ------- Client Specification ------- ;;

--- a/src/main/java/com/appsflyer/donkey/VertxFactory.java
+++ b/src/main/java/com/appsflyer/donkey/VertxFactory.java
@@ -30,6 +30,20 @@ public final class VertxFactory {
   
   public static Vertx create(VertxOptions opts) {
     return Vertx.vertx(opts)
-                .exceptionHandler(ex -> logger.error(ex.getMessage(), ex.getCause()));
+                .exceptionHandler(VertxFactory::defaultExceptionHandler);
+  }
+  
+  private static void defaultExceptionHandler(Throwable ex) {
+    Throwable t = ex;
+    if (logger.isDebugEnabled()) {
+      var stack = ex.getStackTrace();
+      // If we don't have a stack trace we fill it now
+      if (stack == null || stack.length == 0) {
+        t = new RuntimeException(ex);
+      }
+      logger.debug(ex.getMessage(), t);
+    } else {
+      logger.error(ex.getMessage(), ex);
+    }
   }
 }

--- a/src/main/java/com/appsflyer/donkey/client/ClientConfig.java
+++ b/src/main/java/com/appsflyer/donkey/client/ClientConfig.java
@@ -30,7 +30,6 @@ public final class ClientConfig {
   
   private Vertx vertx;
   private WebClientOptions clientOptions;
-  private boolean debug;
   
   private ClientConfig() {}
   
@@ -40,10 +39,6 @@ public final class ClientConfig {
   
   public WebClientOptions clientOptions() {
     return clientOptions;
-  }
-  
-  public boolean debug() {
-    return debug;
   }
   
   public static final class ClientConfigBuilder {
@@ -63,11 +58,6 @@ public final class ClientConfig {
     public ClientConfigBuilder clientOptions(WebClientOptions clientOptions) {
       Objects.requireNonNull(clientOptions, "Client options argument cannot be null");
       instance.clientOptions = clientOptions;
-      return this;
-    }
-    
-    public ClientConfigBuilder debug(boolean val) {
-      instance.debug = val;
       return this;
     }
     

--- a/src/main/java/com/appsflyer/donkey/server/ServerConfig.java
+++ b/src/main/java/com/appsflyer/donkey/server/ServerConfig.java
@@ -41,7 +41,6 @@ public final class ServerConfig {
   private RouteList routeList;
   private ErrorHandler<?> errorHandler;
   private int instances;
-  private boolean debug;
   private boolean addDateHeader;
   private boolean addContentTypeHeader;
   private boolean addServerHeader;
@@ -70,10 +69,6 @@ public final class ServerConfig {
   
   public int instances() {
     return instances;
-  }
-  
-  public boolean debug() {
-    return debug;
   }
   
   boolean addDateHeader() {
@@ -127,11 +122,6 @@ public final class ServerConfig {
   
     public ServerConfigBuilder instances(int val) {
       instance.instances = val;
-      return this;
-    }
-  
-    public ServerConfigBuilder debug(boolean val) {
-      instance.debug = val;
       return this;
     }
     

--- a/src/main/java/com/appsflyer/donkey/server/ServerImpl.java
+++ b/src/main/java/com/appsflyer/donkey/server/ServerImpl.java
@@ -27,7 +27,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.LoggerHandler;
 import io.vertx.ext.web.handler.ResponseContentTypeHandler;
 
 import java.util.ArrayList;
@@ -58,9 +57,6 @@ public final class ServerImpl implements Server {
   
   private void addOptionalHandlers() {
     Collection<Handler<RoutingContext>> handlers = new ArrayList<>();
-    if (config.debug()) {
-      handlers.add(LoggerHandler.create());
-    }
     if (config.addDateHeader()) {
       handlers.add(DateHeaderHandler.create(config.vertx()));
     }

--- a/src/main/java/com/appsflyer/donkey/server/handler/InternalServerErrorHandler.java
+++ b/src/main/java/com/appsflyer/donkey/server/handler/InternalServerErrorHandler.java
@@ -35,7 +35,7 @@ public final class InternalServerErrorHandler implements Handler<RoutingContext>
   
   @Override
   public void handle(RoutingContext ctx) {
-    logger.error("Unhandled exception:", ctx.failure());
-    ctx.response().setStatusCode(500);
+    logger.error("Internal Server Error:", ctx.failure());
+    ctx.response().setStatusCode(500).end();
   }
 }

--- a/src/test/clojure/com/appsflyer/donkey/test_helper.clj
+++ b/src/test/clojure/com/appsflyer/donkey/test_helper.clj
@@ -53,7 +53,7 @@
         (.setDefaultPort (int (:port default-server-options))))))
 
 (defn init-web-client [test-fn]
-  (binding [vertx-client (launch-vertx-client (.-vertx donkey-core))]
+  (binding [vertx-client (launch-vertx-client (-> donkey-core .-config :vertx))]
     (test-fn)
     (.close vertx-client)))
 
@@ -68,7 +68,7 @@
     instance))
 
 (defn init-donkey-server
-  ([test-fn routes] (init-donkey-server test-fn routes nil))
+  ([test-fn routes] (init-donkey-server test-fn routes []))
   ([test-fn routes middleware]
    (binding [donkey-server (launch-donkey-server donkey-core {:routes routes :middleware middleware})]
      (test-fn)
@@ -85,11 +85,11 @@
   and a default client. Both will be closed after the `test-fn` returns.
   The server and client are available inside the test as
   `donkey-server` and `vertx-client` respectively."
-  ([test-fn routes] (run-with-server-and-client test-fn routes nil))
+  ([test-fn routes] (run-with-server-and-client test-fn routes []))
   ([test-fn routes middleware]
    (let [^Donkey donkey-instance (donkey/create-donkey default-donkey-options)]
      (binding [donkey-server (launch-donkey-server donkey-instance {:routes routes :middleware middleware})
-               vertx-client (launch-vertx-client (.-vertx donkey-instance))]
+               vertx-client (launch-vertx-client (-> donkey-instance .-config :vertx))]
        (test-fn)
        (.close vertx-client)
        (is (nil? (server/stop-sync donkey-server)))))))

--- a/src/test/java/com/appsflyer/donkey/server/ServerTest.java
+++ b/src/test/java/com/appsflyer/donkey/server/ServerTest.java
@@ -104,5 +104,4 @@ class ServerTest {
                 }))));
     assertContextSuccess(testContext);
   }
-  
 }


### PR DESCRIPTION
- Debug mode is now set when creating a `Donkey` instance rather than creating
  a `DonkeyServer` or `DonkeyClient`. This fixes issues where enabling debug
  mode on the server/client and not on the other would sometimes disable debug
  mode for both.
- Turned on Clojure spec assertions
- Global exception handler - In debug mode, a stack trace is added to the
  exception if it doesn't include one.
- Fixed release script not pushing changes to GitHub.